### PR TITLE
Removes automatic bundling of CSS (breaking change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Simply import the Crawl component. You can use the `title`, `subTitle`, and `tex
     import React from 'react'
     import Crawl from 'react-star-wars-crawl'
 
+    // Import the necessary styles, or include them another way with your build process
+    import 'react-star-wars-crawl/lib/index.css'
+
     const MyCrawlComponent = () => (
         <Crawl
           title="Episode IV"

--- a/src/Crawl.js
+++ b/src/Crawl.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import './index.css'
 
 const styles = {
   container: {


### PR DESCRIPTION
Hi, thanks for making this component!

This is a breaking change, so I’d totally understand if you didn’t want to merge it, but I just thought I’d open this to see what you though.

The CSS importing didn’t work with my build process until I changed the import statement to:

```js
if (typeof window !== 'undefined') {
  require('index.css')
}
```

Arguably, that’s just an error with my build process, but I’ve found it useful when components just let people import their own styles manually, so they don’t have to deal with any assumptions about people’s build process. For example, this change should let you include the `index.css` file from Sass or PostCSS, if you’re using Webpack or managing all your styles there.